### PR TITLE
remove PartialEq bound

### DIFF
--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -27,6 +27,12 @@ impl<K: PartialEq, V> PartialEq for KeyValue<K, V> {
     }
 }
 
+impl<K, V> Default for HashMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K, V> HashMap<K, V> {
     pub fn new() -> HashMap<K, V> {
         HashMap {

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::trie::Trie;
 
 #[derive(Clone)]
-pub struct HashMap<K: PartialEq, V = ()> {
+pub struct HashMap<K, V = ()> {
     trie: Trie<bool, KeyValue<K, V>>,
     phantom: PhantomData<K>,
 }

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -27,10 +27,12 @@ impl<K: PartialEq, V> PartialEq for KeyValue<K, V> {
     }
 }
 
-pub fn empty<K: PartialEq, V>() -> HashMap<K, V> {
-    HashMap {
-        trie: Trie::empty_store(),
-        phantom: PhantomData,
+impl<K, V> HashMap<K, V> {
+    pub fn new() -> HashMap<K, V> {
+        HashMap {
+            trie: Trie::empty_store(),
+            phantom: PhantomData,
+        }
     }
 }
 
@@ -89,7 +91,7 @@ mod tests {
 
     #[test]
     fn insert_and_retrieve_values_set() {
-        let m1 = empty();
+        let m1 = HashMap::new();
         let m2 = m1.insert(1238).insert(-1).insert(1238);
         assert!(m2.search(&1238));
         assert!(!m1.search(&-1));
@@ -98,7 +100,7 @@ mod tests {
 
     #[test]
     fn insert_and_retrieve_values() {
-        let m1 = empty();
+        let m1 = HashMap::new();
         let m2 = m1.put(1238, 1).put(-1, 10);
         assert_eq!(m2.get(&1238), Some(&1));
         assert_eq!(m1.get(&-1), None);
@@ -115,7 +117,7 @@ mod tests {
             fn hash<H: Hasher>(&self, _: &mut H) {}
         }
 
-        let m = empty().put(K { x: 1 }, 1).put(K { x: -1 }, 10);
+        let m = HashMap::new().put(K { x: 1 }, 1).put(K { x: -1 }, 10);
         assert_eq!(m.get(&K { x: 1 }), Some(&1));
         assert_eq!(m.get(&K { x: -1 }), Some(&10));
     }
@@ -131,7 +133,7 @@ mod tests {
             fn hash<H: Hasher>(&self, _: &mut H) {}
         }
 
-        let m = empty()
+        let m = HashMap::new()
             .put(K { x: 1 }, 1)
             .put(K { x: -1 }, 10)
             .delete(K { x: 1 });

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -13,7 +13,7 @@ impl<T: Clone, U> Clone for Trie<T, U> {
     }
 }
 
-impl<T: PartialEq + Clone, U> Trie<T, U> {
+impl<T, U> Trie<T, U> {
     pub(crate) fn empty_store() -> Trie<T, U> {
         Trie {
             stored_value: Vec::new(),
@@ -26,6 +26,9 @@ impl<T: PartialEq + Clone, U> Trie<T, U> {
             adjecent_nodes: Vec::new(),
         }
     }
+}
+
+impl<T: PartialEq + Clone, U> Trie<T, U> {
     pub fn insert_store<Slc: AsRef<[T]>>(&self, value: Slc, store: U) -> Self {
         let value_ref = value.as_ref();
         let mut new_trie = self.clone();


### PR DESCRIPTION
This makes the api a bit more consistent to HashMap/HashSet. I renamed empty to new, and made it an associated function like in HashMap. Then, I removed the PartialEq bound from the struct, which is good practice. That makes it easier to include the HashMap in another struct without having to propagate the bounds up.